### PR TITLE
Test/gx3-5746/toolsqa-practice-form

### DIFF
--- a/cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
+++ b/cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 // faker usage guide: https://fakerjs.dev/guide/usage
 // faker modules: https://fakerjs.dev/api/
 
-import { objJsonDataHandler } from '@pages/GX3-5746-Practice-Form.Page';
+import { objJsonDataHandler } from '@helper/JsonDataHandler';
 import { objPracticeFormPage } from '@pages/GX3-5746-Practice-Form.Page';
 
 const DATA_FIRST_NAME = faker.person.firstName();

--- a/cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
+++ b/cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
@@ -21,6 +21,8 @@ describe('GX3-5746 |ToolsQA | Forms | Practice Form', () => {
 	beforeEach('PRC: Usuario debe estar en la url Practice Form de ToolsQA', () => {
 		cy.visit('https://demoqa.com/automation-practice-form');
 		cy.url().should('contain', 'practice-form');
+
+		objJsonDataHandler.setAllowedKeys(['firstName', 'lastName', 'email', 'gender', 'phoneNumber', 'birthDate', 'subject', 'hobbies', 'fileName', 'currentAddress', 'state', 'city']);
 	});
 
 	it('GX-5746 - TC01: Validar que se pueda enviar el formulario correctamente (HP)', () => {

--- a/cypress/support/helper/JsonDataHandler.ts
+++ b/cypress/support/helper/JsonDataHandler.ts
@@ -1,0 +1,68 @@
+class JsonDataHandler {
+	private data: Record<string, any>;
+	private defaultPath: string;
+
+	constructor() {
+		this.data = {};
+		this.defaultPath = '@data/Elements';
+	}
+
+	setData(newData: Record<string, any>): void {
+		this.data = { ...this.data, ...newData };
+	}
+
+	getData(): Record<string, any> {
+		return this.data;
+	}
+
+	readValue(key: string): any {
+		return this.data[key];
+	}
+
+	writeValue(key: string, value: any): void {
+		this.data[key] = value;
+	}
+
+	async saveToFile(fileName: string, customPath?: string): Promise<void> {
+		// Solo carga las librerías si son necesarias
+		const { writeFile } = await import('fs/promises');
+		const path = await import('path');
+
+		const filePath = path.join(customPath || this.defaultPath, `${fileName}.json`);
+		await writeFile(filePath, JSON.stringify(this.data, null, 2), { encoding: 'utf-8' });
+	}
+
+	async loadFromFile(fileName: string, customPath?: string): Promise<any> {
+		// Solo carga las librerías si son necesarias
+		const { readFile, stat } = await import('fs/promises');
+		const path = await import('path');
+
+		const filePath = path.join(customPath || this.defaultPath, `${fileName}.json`);
+		try {
+			await stat(filePath); // Verifica si el archivo existe
+			const fileContent = await readFile(filePath, 'utf-8');
+			this.data = JSON.parse(fileContent);
+			return this.data;
+		} catch (error) {
+			if (error instanceof Error) {
+				const err = error as NodeJS.ErrnoException;
+				if (err.code === 'ENOENT') {
+					throw new Error(`El archivo ${fileName}.json no existe en la carpeta ${customPath || this.defaultPath}.`);
+				}
+			}
+			throw error; // Re-lanza otros errores
+		}
+	}
+}
+
+export const objJsonDataHandler = new JsonDataHandler();
+
+/*****************************************************
+ // Cargar datos desde el fixture
+	cy.fixture('miFixture').then((data) => {
+    	objJsonDataHandler.setData(data);
+	}); */
+
+/*	// Guardar datos en un fixture
+	objJsonDataHandler.saveToFile('miFixture');
+*****************************************************/

--- a/cypress/support/helper/JsonDataHandler.ts
+++ b/cypress/support/helper/JsonDataHandler.ts
@@ -1,24 +1,40 @@
 class JsonDataHandler {
 	private data: Record<string, any>;
+	private allowedKeys: string[] | null;
 
 	constructor() {
 		this.data = {};
+		this.allowedKeys = null;
 	}
 
-	setData(newData: Record<string, any>): void {
-		this.data = { ...this.data, ...newData };
+	setAllowedKeys(_allowedKeys: string[]): void {
+		this.allowedKeys = _allowedKeys;
+	}
+
+	setData(_newData: Record<string, any>): void {
+		for (const key of Object.keys(_newData)) {
+			if (this.allowedKeys === null || this.allowedKeys.includes(key)) {
+				this.data[key] = _newData[key];
+			} else {
+				console.warn(`Key "${key}" is not allowed and will not be set.`);
+			}
+		}
 	}
 
 	getData(): Record<string, any> {
 		return this.data;
 	}
 
-	readValue(key: string): any {
-		return this.data[key];
+	readValue(_key: string): any {
+		return this.data[_key];
 	}
 
-	writeValue(key: string, value: any): void {
-		this.data[key] = value;
+	writeValue(_key: string, _value: any): void {
+		if (this.allowedKeys === null || this.allowedKeys.includes(_key)) {
+			this.data[_key] = _value;
+		} else {
+			console.warn(`Key "${_key}" is not allowed and will not be set.`);
+		}
 	}
 }
 

--- a/cypress/support/helper/JsonDataHandler.ts
+++ b/cypress/support/helper/JsonDataHandler.ts
@@ -1,13 +1,8 @@
-import * as fs from 'fs';
-import * as path from 'path';
-
 class JsonDataHandler {
 	private data: Record<string, any>;
-	private defaultPath: string;
 
 	constructor() {
 		this.data = {};
-		this.defaultPath = '@data/Elements';
 	}
 
 	setData(newData: Record<string, any>): void {
@@ -25,40 +20,6 @@ class JsonDataHandler {
 	writeValue(key: string, value: any): void {
 		this.data[key] = value;
 	}
-
-	saveToFile(fileName: string, customPath?: string): void {
-		const filePath = path.join(customPath || this.defaultPath, `${fileName}.json`);
-		fs.writeFile(filePath, JSON.stringify(this.data, null, 2), 'utf-8', err => {
-			if (err) {
-				console.error('Error writing file:', err);
-			}
-		});
-	}
-
-	loadFromFile(fileName: string, customPath?: string): void {
-		const filePath = path.join(customPath || this.defaultPath, `${fileName}.json`);
-		fs.readFile(filePath, 'utf-8', (err, data) => {
-			if (err) {
-				if (err.code === 'ENOENT') {
-					console.error(`El archivo ${fileName}.json no existe en la carpeta ${customPath || this.defaultPath}.`);
-				} else {
-					console.error('Error reading file:', err);
-				}
-			} else {
-				this.data = JSON.parse(data);
-			}
-		});
-	}
 }
 
 export const objJsonDataHandler = new JsonDataHandler();
-
-/*****************************************************
- // Cargar datos desde el fixture
-	cy.fixture('miFixture').then((data) => {
-    	objJsonDataHandler.setData(data);
-	}); */
-
-/*	// Guardar datos en un fixture
-	objJsonDataHandler.saveToFile('miFixture');
-*****************************************************/

--- a/cypress/support/pages/GX3-5746-Practice-Form.Page.ts
+++ b/cypress/support/pages/GX3-5746-Practice-Form.Page.ts
@@ -1,27 +1,3 @@
-class JsonDataHandler {
-	private data: Record<string, any>;
-
-	constructor() {
-		this.data = {};
-	}
-
-	setData(newData: Record<string, any>): void {
-		this.data = { ...this.data, ...newData };
-	}
-
-	getData(): Record<string, any> {
-		return this.data;
-	}
-
-	readValue(key: string): any {
-		return this.data[key];
-	}
-
-	writeValue(key: string, value: any): void {
-		this.data[key] = value;
-	}
-}
-
 class PracticeForm {
 	public get = {
 		inputFirstName: () => cy.get('input#firstName'),
@@ -202,5 +178,4 @@ class PracticeForm {
 	}
 }
 
-export const objJsonDataHandler = new JsonDataHandler();
 export const objPracticeFormPage = new PracticeForm();


### PR DESCRIPTION
# **Nomenclatura del Título del Pull Request**

> "Test(`GX3-5746`): `ToolsQA | Forms | Practice Form`"

## Feature to be Test Automated

- `GX3-5746`: [ToolsQA | Forms | Practice Form]()https://upexgalaxy47.atlassian.net/browse/GX3-5746

## Summary of Changes

> Creado una clase para manejar un JSON para contener los datos introducidos y validar posteriormente el resultado

## Test Results Verification

![TD Results GX3-5746](https://github.com/user-attachments/assets/62808d18-8015-4580-ad7a-28d178ee8bed)

## Git Log

```bash
commit f2269fdb71cda773feae7ceb992b99e08b538347 (HEAD -> test/GX3-5746/ToolsQA-Practice-Form, origin/test/GX3-5746/ToolsQA-Practice-Form)
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Mon Dec 9 09:43:00 2024 +0100

    test (GX3-5746) Added allowedKeys to JsonDataHandler Class
    to inprove reading code
     On branch test/GX3-5746/ToolsQA-Practice-Form
            modified:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            modified:   cypress/support/helper/JsonDataHandler.ts

commit 4233fd7c74d1d0877eb97c64b6c5f20b70364102
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Sat Dec 7 12:54:16 2024 +0100

    fix: erased fixture methods
     On branch test/GX3-5746/ToolsQA-Practice-Form
            modified:   cypress/support/helper/JsonDataHandler.ts

commit 24c1730ad9b906c37dc43825816040069ca2a57c
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Sat Dec 7 11:57:17 2024 +0100

    refactor (GX3-5746) Changed location of the JsonDataHandler class
    and added methods to handle it with fixture
     On branch test/GX3-5746/ToolsQA-Practice-Form
            modified:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            new file:   cypress/support/helper/JsonDataHandler.ts
            modified:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit 966230c8bb464192d37d2e86f761d126cee3f46c
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Thu Dec 5 02:03:13 2024 +0100

    fix (GX3-5746) Casting HTMLInputElement to recognize the files property of the input
     On branch test/GX3-5746/ToolsQA-Practice-Form
            modified:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            modified:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit d2aad41f13432ee35f92e517ba0f2e1b6f84a7a0
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Thu Dec 5 01:30:29 2024 +0100

    refact (GX3-5746) Change location of validations to main file
    Page object and JSON object works independently
    Property Data of JSON object was defined
    Types of some blocks were defined
    Actions and data saving were separated.
     On branch test/GX3-5746/ToolsQA-Practice-Form
            deleted:    .github/workflows/build-GX3-5746.yml
            deleted:    .github/workflows/sanityTest-GX3-5746.yml
            modified:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            modified:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit 08234ef6b677bd0ba980c55fa63e5e44ad9ea150
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Dec 4 14:57:58 2024 +0100

    test (GX3-5746) Checks if element, subject and hobby, is included in array before push it
     On branch test/GX3-5746/ToolsQA-Practice-Form
            modified:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            modified:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit b9935d959d4bfe1bd35067e832b0527586c0ff67
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Dec 4 12:26:27 2024 +0100

    test (GX3-5746) Added all validations to smoke workflow.

    Declared a new class in Page.ts to use a json dynamic property object
    Typed or selected data is stored in that json propert to validate later their content with table result
    Dates are formated to the same format, to be able to compare them
    Subjects and Hobbies are stored like array in a key of the json property
     On branch test/GX3-5746/ToolsQA-Practice-Form
            modified:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            modified:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit 1c08b97123d6c8142bc2cecbb3667c7a38f63783
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Tue Dec 3 13:07:23 2024 +0100

    test (GX3-5746) Add class properties to store DOM values
    to validate result table
            modified:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit a350f80efc5b6481413cba90124c45a1a9258022
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Mon Dec 2 20:35:26 2024 +0100

    test (GX3-5746) Add steps to ts
    to do: validate result
     On branch test/GX3-5746/ToolsQA-Practice-Form
            modified:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            modified:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit 3f2ba7214ac257404d43f316a90298842efad33a
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Mon Dec 2 13:54:15 2024 +0100

    test (GX3-5746) Add more steps to HP
    to fix. faker returns a phone number with symbols. Must erase them of
    number to type it on input
     On branch test/GX3-5746/ToolsQA-Practice-Form
            modified:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            modified:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit fadf2905a1560707e7646baa078391792b05b5ed
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Mon Dec 2 12:41:48 2024 +0100

    fix (GX3-5746) fix title
            modified:   coverage/S49/GX3-5746.md

commit e46e0e2c7cc69e9bae7ace0d6b946836c2430b6f
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Mon Dec 2 12:39:02 2024 +0100

    fix (GX3-5746) fix conflicts
            new file:   coverage/S49/GX3-5746.md
            new file:   cypress/e2e/Tests/Forms/GX3-5746-Practice-Form.cy.ts
            new file:   cypress/support/pages/GX3-5746-Practice-Form.Page.ts

commit 2dae0eee7e60a1595d159af5d92f0bc8b252df63
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Mon Dec 2 12:36:14 2024 +0100

    fix (GX3-5746) fix conflicts
            deleted:    .github/workflows/sanity-verogeid.yml
```

## Observations

> Manejo dos objetos. Uno correspondiente a la página y otro para almacenar los datos en un JSON dinámico.

## Checklist

- [x] Mi código sigue las pautas de estilo de este proyecto, revisando la nomenclatura usada y corregiendo cualquier error ortográfico.

- [x] He realizado una revisión doble de mi propio código y he comentado especialmente en áreas difíciles de entender.

- [x] Las pruebas automatizadas nuevas y existentes pasan localmente y he comprobado que mi código funciona sin generar nuevas advertencias (IMPORTANTE)

- [x] He ejecutado el Pipeline de "Sanity Test" específicamente para importar mis Resultados de Prueba a Jira y he comprobado así que mi código de prueba funciona también en CI (IMPORTANTE)

- [x] Confirmo que he considerado agregar documentación nueva al proyecto (en la carpeta `docs/`) en caso de ser necesario. Véase en la descripción del PR si he agregado o no.
